### PR TITLE
fixed a problem where the wrong logger was used for measuring log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add metrics-play dependency in your `build.sbt`:
 
 ```scala
 libraryDependencies += Seq(
-  "org.zalando" %% "markscheider" % "2.5.1"
+  "org.zalando" %% "markscheider" % "2.5.2"
 )
 ```
 

--- a/app/org/zalando/markscheider/MetricsPlugin.scala
+++ b/app/org/zalando/markscheider/MetricsPlugin.scala
@@ -12,6 +12,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import play.api._
 import play.api.inject.{ ApplicationLifecycle, Module }
 import javax.inject._
+
+import ch.qos.logback.classic.LoggerContext
+import org.slf4j.LoggerFactory
+
 import scala.concurrent.Future
 import scala.language.implicitConversions
 
@@ -49,10 +53,12 @@ class MetricsPlugin @Inject() (
         if (logbackEnabled) {
           val appender: InstrumentedAppender = new InstrumentedAppender(registry)
 
-          val logger: classic.Logger = Logger.logger.asInstanceOf[classic.Logger]
-          appender.setContext(logger.getLoggerContext)
+          val factory = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+          val rootLogger = factory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
+
+          appender.setContext(rootLogger.getLoggerContext)
           appender.start()
-          logger.addAppender(appender)
+          rootLogger.addAppender(appender)
         }
       }
 

--- a/tut/README.md
+++ b/tut/README.md
@@ -13,7 +13,7 @@ Add metrics-play dependency in your `build.sbt`:
 
 ```scala
 libraryDependencies += Seq(
-  "org.zalando" %% "markscheider" % "2.5.1"
+  "org.zalando" %% "markscheider" % "2.5.2"
 )
 ```
 


### PR DESCRIPTION
In the old implementation, the default play logger was instrumented to get the number of log entries written. However, since not all
log entries are written through the default logger normally, this number tended to be wrong. I now attach to the root logger which
should cover all the cases.
