### PR TITLE
don’t record failed external HTTP calls as “nonhttp”

### DIFF
--- a/app/org/zalando/markscheider/CallTimer.scala
+++ b/app/org/zalando/markscheider/CallTimer.scala
@@ -59,7 +59,7 @@ class CallTimer @Inject() (registries: MetricRegistries, configuration: Configur
     }
   }
 
-  private def recordFailedExternalHttpCall(
+  def recordFailedExternalHttpCall(
     requestId:  Option[Long],
     duration:   Duration,
     name:       String,


### PR DESCRIPTION
Currently failed external HTTP calls are added to a metric implying they are nonhttp.

I decided to add this privately for now so not to change the public API but if you think it's reasonable, it could also be made public.