### PR TITLE
Handle unhandled exceptions in MetricsFilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
+dist: trusty
 scala:
-  - 2.12.2
+  - 2.12.10
 jdk:
   - oraclejdk8

--- a/app/org/zalando/markscheider/MetricsFilter.scala
+++ b/app/org/zalando/markscheider/MetricsFilter.scala
@@ -2,6 +2,7 @@ package org.zalando.markscheider
 
 import java.util.concurrent.TimeUnit
 
+import akka.stream.Materializer
 import com.codahale.metrics.MetricRegistry.name
 import com.codahale.metrics._
 import com.google.inject.Inject
@@ -9,63 +10,67 @@ import play.api.Configuration
 import play.api.mvc._
 import play.api.routing.Router
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, Future }
 
 class MetricsFilter @Inject() (
-    registries:    MetricRegistries,
-    callTimer:     CallTimer,
+    registries: MetricRegistries,
+    callTimer: CallTimer,
     configuration: Configuration
-)(implicit ec: ExecutionContext)
-  extends EssentialFilter {
+)(implicit val mat: Materializer, val ec: ExecutionContext)
+    extends Filter {
 
   val registry = registries.getOrCreate
   val prefix = configuration.getOptional[String]("org.zalando.markscheider.prefix.http").getOrElse("zmon.response")
   val selfPrefix = configuration.getOptional[String]("org.zalando.markscheider.prefix.self-http").getOrElse("zmon.self.response")
-  val recordExternalCallTimes = configuration.getOptional[Boolean]("org.zalando.markscheider.recordExternalCallTimes").getOrElse(true)
+  val recordExternalCallTimes =
+    configuration.getOptional[Boolean]("org.zalando.markscheider.recordExternalCallTimes").getOrElse(true)
 
   def requestsTimer: Timer = registry.timer(name(classOf[MetricsFilter], "requestTimer"))
   def activeRequests: Counter = registry.counter(name(classOf[MetricsFilter], "activeRequests"))
 
-  def apply(next: EssentialAction): EssentialAction = new EssentialAction {
+  def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+    val startTime = System.currentTimeMillis()
+    val method = rh.attrs.get(Router.Attrs.HandlerDef).map(_.method).getOrElse("MetricsFilter")
+    val controller = rh.attrs.get(Router.Attrs.HandlerDef).map(_.controller).getOrElse(getClass.getPackage.getName)
 
-    def apply(rh: RequestHeader) = {
-      val startTime = System.currentTimeMillis()
-      val method = rh.attrs.get(Router.Attrs.HandlerDef).map(_.method).getOrElse("MetricsFilter")
-      val controller = rh.attrs.get(Router.Attrs.HandlerDef).map(_.controller).getOrElse(getClass.getPackage.getName)
+    val globalCtx = requestsTimer.time()
 
-      val globalCtx = requestsTimer.time()
+    def logCompleted(result: Result): Result = {
+      val duration: Long = System.currentTimeMillis() - startTime
 
-        def logCompleted(result: Result): Result = {
-          val duration: Long = System.currentTimeMillis() - startTime
+      registry.timer(s"$prefix.${result.header.status}.${rh.method}.$controller.$method").update(duration, TimeUnit.MILLISECONDS)
+      registry
+        .timer(s"$prefix.${result.header.status / 100}xx.${rh.method}.$controller.$method")
+        .update(duration, TimeUnit.MILLISECONDS)
+      registry.timer(s"$prefix.${result.header.status / 100}xx.${rh.method}.ALL").update(duration, TimeUnit.MILLISECONDS)
+      registry.timer(s"$prefix.${result.header.status / 100}xx.ALL.ALL").update(duration, TimeUnit.MILLISECONDS)
 
-          registry.timer(s"$prefix.${result.header.status}.${rh.method}.$controller.$method")
-            .update(duration, TimeUnit.MILLISECONDS)
-          registry.timer(s"$prefix.${result.header.status / 100}xx.${rh.method}.$controller.$method")
-            .update(duration, TimeUnit.MILLISECONDS)
-          registry.timer(s"$prefix.${result.header.status / 100}xx.${rh.method}.ALL")
-            .update(duration, TimeUnit.MILLISECONDS)
-          registry.timer(s"$prefix.${result.header.status / 100}xx.ALL.ALL")
-            .update(duration, TimeUnit.MILLISECONDS)
+      if (recordExternalCallTimes) {
+        val externalCallTimes = callTimer.readExternalCallTimes(rh.id).toMillis
+        registry
+          .timer(s"$selfPrefix.${result.header.status}.${rh.method}.$controller.$method")
+          .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
+        registry
+          .timer(s"$selfPrefix.${result.header.status / 100}xx.${rh.method}.$controller.$method")
+          .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
+        registry
+          .timer(s"$selfPrefix.${result.header.status / 100}xx.${rh.method}.ALL")
+          .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
+        registry
+          .timer(s"$selfPrefix.${result.header.status / 100}xx.ALL.ALL")
+          .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
+      }
 
-          if (recordExternalCallTimes) {
-            val externalCallTimes = callTimer.readExternalCallTimes(rh.id).toMillis
-            registry.timer(s"$selfPrefix.${result.header.status}.${rh.method}.$controller.$method")
-              .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
-            registry.timer(s"$selfPrefix.${result.header.status / 100}xx.${rh.method}.$controller.$method")
-              .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
-            registry.timer(s"$selfPrefix.${result.header.status / 100}xx.${rh.method}.ALL")
-              .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
-            registry.timer(s"$selfPrefix.${result.header.status / 100}xx.ALL.ALL")
-              .update(duration - externalCallTimes, TimeUnit.MILLISECONDS)
-          }
-
-          activeRequests.dec()
-          globalCtx.stop()
-          result
-        }
-
-      activeRequests.inc()
-      next(rh).map(logCompleted)
+      activeRequests.dec()
+      globalCtx.stop()
+      result
     }
+
+    activeRequests.inc()
+
+    next(rh).transform(logCompleted, exception => {
+      logCompleted(Results.InternalServerError)
+      exception
+    })
   }
 }


### PR DESCRIPTION
Description and implementation taken from https://github.com/kenshoo/metrics-play/pull/33

> In the case of an uncaught exception during a request, logCompleted is never called. Common practice in Play apps is to have a global onError handler that returns an HTTP 500 result. Due to logCompleted never being called, these 500 results do not get caught by the MetricsFilter. Additionally, their timing is ignored, and activeRequests is never decremented.
> 
> This change addresses these issues by calling logCompleted with an InternalServerError result before propagating the exception. This also exchanges EssentialFilter for Filter, as EssentialFilter is lower-level and is not necessary for this class.
